### PR TITLE
Switched sublist3r option to module call

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A simple tool that can be scheduled to run in the background to track changes to target subdomains. Made this to run on a schedule to automate subdomain discovery.
 New subdomains are pushed to a slack webhook.
 
+## Setup
+Before running, copy the config-sample.ini file to config.ini, then fill in the appropriate webhook URL for Slack integration.
+
 ## Usage
 Syntax: `subcompare.py masterfile.txt newfile.txt`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Run an initial sublist3r scan and send the output to a master file.
 Schedule sublist3r to scan a domain and output the results to a new file.
 Schedule subcompare to run after the sublist3r scan.
 
-
-Additionally, I've added the ability to run sublist3r from within subcompare with the --domain flag. The sublist3r output goes to the newfile, then the main script runs. Sublist3r must be installed on the system for this to work properly, as it's called as a module.
+## Using Sublist3r from subcompare
+Additionally, I've added the ability to run sublist3r from within subcompare with the --domain flag. The sublist3r output goes to the newfile, then the main script runs. Sublist3r must be installed and importable on the system for this to work properly, as it's called as a module.
 

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Schedule sublist3r to scan a domain and output the results to a new file.
 Schedule subcompare to run after the sublist3r scan.
 
 
-Additionally, I've added the ability to launch sublist3r from within subcompare with the --domain flag. The sublist3r output goes to the newfile, then the main script runs.
+Additionally, I've added the ability to run sublist3r from within subcompare with the --domain flag. The sublist3r output goes to the newfile, then the main script runs. Sublist3r must be installed on the system for this to work properly, as it's called as a module.
 

--- a/subcompare.py
+++ b/subcompare.py
@@ -34,7 +34,7 @@ if args.verbose:
 if args.domain:
     #Wait to import sublist3r until option is selected, in case sublist3r is not installed
     import sublist3r
-    subdomains = sublist3r.main(args.domain, 0, args.newFile, ports= None, silent=True, verbose=False, enable_bruteforce= False)
+    subdomains = sublist3r.main(args.domain, 0, args.newFile, ports=None, silent=True, verbose=False, enable_bruteforce=False, engines=None)
 
 #Variable setting
 config = configparser.ConfigParser()

--- a/subcompare.py
+++ b/subcompare.py
@@ -19,7 +19,7 @@ import configparser
 parser = argparse.ArgumentParser(description="Track new subdomains")
 parser.add_argument("masterFile", help="Master subdomain list")
 parser.add_argument("newFile", help="New subdomain list")
-parser.add_argument("-d", "--domain", help="Domain to run through sublist3r")
+parser.add_argument("-d", "--domain", help="Domain to run through sublist3r (sublist3r must be installed)")
 parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
 args = parser.parse_args()
 
@@ -32,7 +32,9 @@ if args.verbose:
 
 #Run sublist3r
 if args.domain:
-    os.system("sublist3r -d " + args.domain + " -o " + args.newFile)
+    #Wait to import sublist3r until option is selected, in case sublist3r is not installed
+    import sublist3r
+    subdomains = sublist3r.main(args.domain, 0, args.newFile, ports= None, silent=True, verbose=False, enable_bruteforce= False)
 
 #Variable setting
 config = configparser.ConfigParser()

--- a/subcompare.py
+++ b/subcompare.py
@@ -14,6 +14,10 @@ import requests
 import argparse
 import os
 import configparser
+try:
+    import sublist3r
+except ImportError:
+    pass
 
 #Argument parsing
 parser = argparse.ArgumentParser(description="Track new subdomains")
@@ -32,9 +36,11 @@ if args.verbose:
 
 #Run sublist3r
 if args.domain:
-    #Wait to import sublist3r until option is selected, in case sublist3r is not installed
-    import sublist3r
-    subdomains = sublist3r.main(args.domain, 0, args.newFile, ports=None, silent=True, verbose=False, enable_bruteforce=False, engines=None)
+    # Check if sublist3r was imported
+    if not 'sublist3r' in dir():
+        print("Sublist3r could not be imported. Skipping sublist3r scan.\n")
+    else:
+        subdomains = sublist3r.main(args.domain, 0, args.newFile, ports=None, silent=True, verbose=False, enable_bruteforce=False, engines=None)
 
 #Variable setting
 config = configparser.ConfigParser()


### PR DESCRIPTION
Changed the sublist3r option from executing a shell command to using the module call. Requires sublist3r to be installed as a Python module.